### PR TITLE
Fix paths and change build configuration to Debug

### DIFF
--- a/.github/workflows/GoogleTest.yml
+++ b/.github/workflows/GoogleTest.yml
@@ -28,10 +28,10 @@ jobs:
         uses: microsoft/setup-msbuild@v2
 
       - name: Restore NuGet
-        run: nuget restore MultiSocketRUDP.sln
+        run: nuget restore MultiSocketRUDP/MultiSocketRUDP.sln
 
       - name: Build Solution (x64 Release)
-        run: msbuild MultiSocketRUDP.sln /m /p:Configuration=Release /p:Platform=x64
+        run: msbuild MultiSocketRUDP/MultiSocketRUDP.sln /m /p:Configuration=Debug /p:Platform=x64
 
       - name: Run GTests with Retry
         shell: pwsh


### PR DESCRIPTION
Updated paths for NuGet restore and MSBuild commands to point to the correct solution file location and changed build configuration to Debug.