### PR TITLE
* 재전송 제어를 dead-heap 기반 스케줄러로 전환

### DIFF
--- a/MultiSocketRUDP/CoreTest/MockHelpers.h
+++ b/MultiSocketRUDP/CoreTest/MockHelpers.h
@@ -69,12 +69,10 @@ public:
 		return sendPacketReturn;
 	}
 
-	[[nodiscard]]
-	bool EraseSendPacketInfo(SendPacketInfo* target, const ThreadIdType _) override
+	void MarkSendPacketInfoErased(SendPacketInfo* target, const ThreadIdType _) override
 	{
 		++eraseSendPacketInfoCount;
 		lastErasedPacketInfo = target;
-		return eraseSendPacketInfoReturn;
 	}
 
 	[[nodiscard]]
@@ -114,7 +112,6 @@ public:
 
 	int eraseSendPacketInfoCount = 0;
 	SendPacketInfo* lastErasedPacketInfo = nullptr;
-	bool eraseSendPacketInfoReturn = true;
 
 	bool sendPacketReturn = true;
 	int  sendPacketCount = 0;

--- a/MultiSocketRUDP/CoreTest/RUDPIOHandlerTest.cpp
+++ b/MultiSocketRUDP/CoreTest/RUDPIOHandlerTest.cpp
@@ -5,6 +5,7 @@
 #include "MultiSocketRUDPCore.h"
 #include "IOContext.h"
 #include "SendPacketInfo.h"
+#include "RetransmissionScheduler.h"
 #include "MockRIOManager.h"
 #include "MockSessionDelegate.h"
 
@@ -41,7 +42,7 @@ public:
 //   MockRIOManager      - RIOReceiveEx / RIOSendEx 반환값 제어
 //   MockSessionDelegate - 소켓, RecvContext, SendContext 등 제어
 //   CTLSMemoryPool<IOContext> - IOContext 풀 (OP_SEND 테스트에서 직접 사용)
-//   sendPacketInfoList / sendPacketInfoListLock - 재전송 목록 (threadId 0 전용)
+//   retransmissionSchedulers - 재전송 스케줄러 (threadId 0 전용)
 // ============================================================
 class RUDPIOHandlerTest : public ::testing::Test
 {
@@ -52,15 +53,15 @@ protected:
 
     void SetUp() override
     {
-        sendPacketInfoList.emplace_back();
-        sendPacketInfoListLock.push_back(std::make_unique<std::mutex>());
+        auto scheduler = std::make_unique<RetransmissionScheduler>();
+        scheduler->wakeEventHandle = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+        retransmissionSchedulers.push_back(std::move(scheduler));
 
         handler = std::make_unique<RUDPIOHandler>(
             mockRIO,
             mockDelegate,
             contextPool,
-            sendPacketInfoList,
-            sendPacketInfoListLock,
+            retransmissionSchedulers,
             MAX_HOLDING_SIZE,
             RETRANSMIT_MS);
     }
@@ -68,6 +69,13 @@ protected:
     void TearDown() override
     {
         handler.reset();
+        for (const auto& scheduler : retransmissionSchedulers)
+        {
+            if (scheduler != nullptr && scheduler->wakeEventHandle != NULL)
+            {
+                CloseHandle(scheduler->wakeEventHandle);
+            }
+        }
     }
 
     // ── 의존성 ──────────────────────────────────────────────
@@ -75,8 +83,7 @@ protected:
     MockSessionDelegate mockDelegate;
     CTLSMemoryPool<IOContext> contextPool{ 8, false };
 
-    std::vector<std::list<SendPacketInfo*>>   sendPacketInfoList;
-    std::vector<std::unique_ptr<std::mutex>>  sendPacketInfoListLock;
+    std::vector<std::unique_ptr<RetransmissionScheduler>> retransmissionSchedulers;
 
     std::unique_ptr<RUDPIOHandler> handler;
 
@@ -105,6 +112,16 @@ protected:
         ctx->session = &session;
         return ctx;
     }
+
+    SendPacketInfo* AllocSendPacketInfo(const PacketSequence sequence = 1)
+    {
+        NetBuffer* buffer = NetBuffer::Alloc();
+        SendPacketInfo* info = sendPacketInfoPool->Alloc();
+        EXPECT_NE(buffer, nullptr);
+        EXPECT_NE(info, nullptr);
+        info->Initialize(nullptr, 0, buffer, sequence, false);
+        return info;
+    }
 };
 
 // ============================================================
@@ -113,10 +130,11 @@ protected:
 
 TEST_F(RUDPIOHandlerTest, Handler_CreateAndDestroy_NoCrash)
 {
-    std::vector<std::list<SendPacketInfo*>>  infoList;
-    std::vector<std::unique_ptr<std::mutex>> lockList;
-    infoList.emplace_back();
-    lockList.push_back(std::make_unique<std::mutex>());
+    std::vector<std::unique_ptr<RetransmissionScheduler>> localSchedulers;
+    auto scheduler = std::make_unique<RetransmissionScheduler>();
+    scheduler->wakeEventHandle = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+    HANDLE wakeEventHandle = scheduler->wakeEventHandle;
+    localSchedulers.push_back(std::move(scheduler));
 
     MockRIOManager      localRIO;
     MockSessionDelegate localDelegate;
@@ -125,14 +143,103 @@ TEST_F(RUDPIOHandlerTest, Handler_CreateAndDestroy_NoCrash)
     EXPECT_NO_THROW({
         RUDPIOHandler localHandler(
             localRIO, localDelegate, localPool,
-            infoList, lockList,
+            localSchedulers,
             MAX_HOLDING_SIZE, RETRANSMIT_MS);
         });
+
+    if (wakeEventHandle != NULL)
+    {
+        CloseHandle(wakeEventHandle);
+    }
 }
 
 // ============================================================
 // 2. IOCompleted — null context
 // ============================================================
+
+TEST_F(RUDPIOHandlerTest, RetransmissionScheduler_PushAddsReferenceAndSignalsWakeEvent)
+{
+    SendPacketInfo* info = AllocSendPacketInfo();
+
+    auto& scheduler = *retransmissionSchedulers[THREAD_ID];
+    {
+        std::scoped_lock lock(scheduler.lock);
+        PushRetransmissionSchedule(scheduler, *info, std::chrono::steady_clock::now());
+        ASSERT_EQ(scheduler.heap.size(), 1);
+        EXPECT_EQ(scheduler.heap.top().info, info);
+        EXPECT_EQ(scheduler.heap.top().version, info->scheduleVersion);
+    }
+    EXPECT_TRUE(SignalRetransmissionWakeEvent(scheduler));
+    EXPECT_EQ(info->refCount.load(std::memory_order_acquire), 2);
+    EXPECT_EQ(WaitForSingleObject(scheduler.wakeEventHandle, 0), WAIT_OBJECT_0);
+
+    {
+        std::scoped_lock lock(scheduler.lock);
+        SendPacketInfo::Free(scheduler.heap.top().info);
+        scheduler.heap.pop();
+    }
+    SendPacketInfo::Free(info);
+}
+
+TEST_F(RUDPIOHandlerTest, RetransmissionScheduler_RequeueMarksOlderHeapEntryStaleByVersion)
+{
+    SendPacketInfo* info = AllocSendPacketInfo();
+    auto& scheduler = *retransmissionSchedulers[THREAD_ID];
+
+    {
+        std::scoped_lock lock(scheduler.lock);
+        PushRetransmissionSchedule(scheduler, *info, std::chrono::steady_clock::now());
+        PushRetransmissionSchedule(scheduler, *info, std::chrono::steady_clock::now());
+    }
+
+    size_t staleCount = 0;
+    size_t currentCount = 0;
+    {
+        std::scoped_lock lock(scheduler.lock);
+        ASSERT_EQ(scheduler.heap.size(), 2);
+        while (not scheduler.heap.empty())
+        {
+            const auto entry = scheduler.heap.top();
+            scheduler.heap.pop();
+            if (entry.version == entry.info->scheduleVersion)
+            {
+                ++currentCount;
+            }
+            else
+            {
+                ++staleCount;
+            }
+            SendPacketInfo::Free(entry.info);
+        }
+    }
+
+    EXPECT_EQ(staleCount, 1);
+    EXPECT_EQ(currentCount, 1);
+    SendPacketInfo::Free(info);
+}
+
+TEST_F(RUDPIOHandlerTest, RetransmissionScheduler_ErasedPacketEntryReturnsHeapReference)
+{
+    SendPacketInfo* info = AllocSendPacketInfo();
+    auto& scheduler = *retransmissionSchedulers[THREAD_ID];
+
+    {
+        std::scoped_lock lock(scheduler.lock);
+        PushRetransmissionSchedule(scheduler, *info, std::chrono::steady_clock::now());
+        info->isErasedPacketInfo.store(true, std::memory_order_release);
+    }
+
+    {
+        std::scoped_lock lock(scheduler.lock);
+        ASSERT_EQ(scheduler.heap.size(), 1);
+        SendPacketInfo* erasedInfo = scheduler.heap.top().info;
+        scheduler.heap.pop();
+        EXPECT_TRUE(erasedInfo->isErasedPacketInfo.load(std::memory_order_acquire));
+        SendPacketInfo::Free(erasedInfo);
+    }
+    EXPECT_EQ(info->refCount.load(std::memory_order_acquire), 1);
+    SendPacketInfo::Free(info);
+}
 
 TEST_F(RUDPIOHandlerTest, IOCompleted_NullContext_ReturnsFalse)
 {

--- a/MultiSocketRUDP/MultiSocketRUDPServer/IMultiSocketRUDPCore.h
+++ b/MultiSocketRUDP/MultiSocketRUDPServer/IMultiSocketRUDPCore.h
@@ -14,8 +14,7 @@ public:
 	[[nodiscard]]
 	virtual bool SendPacket(SendPacketInfo* sendPacketInfo) const = 0;
 	virtual void PushToDisconnectTargetSession(RUDPSession& session) = 0;
-	[[nodiscard]]
-	virtual bool EraseSendPacketInfo(OUT SendPacketInfo* eraseTarget, ThreadIdType threadId) = 0;
+	virtual void MarkSendPacketInfoErased(OUT SendPacketInfo* eraseTarget, ThreadIdType threadId) = 0;
 
 	virtual void DisconnectSession(SessionIdType disconnectTargetSessionId) const = 0;
 

--- a/MultiSocketRUDP/MultiSocketRUDPServer/MultiSocketRUDP.vcxproj
+++ b/MultiSocketRUDP/MultiSocketRUDPServer/MultiSocketRUDP.vcxproj
@@ -73,6 +73,7 @@
     <ClInclude Include="RUDPSessionFunctionDelegate.h" />
     <ClInclude Include="RUDPSessionManager.h" />
     <ClInclude Include="RUDPThreadManager.h" />
+    <ClInclude Include="RetransmissionScheduler.h" />
     <ClInclude Include="SendPacketInfo.h" />
     <ClInclude Include="SessionCryptoContext.h" />
     <ClInclude Include="SessionPacketOrderer.h" />

--- a/MultiSocketRUDP/MultiSocketRUDPServer/MultiSocketRUDP.vcxproj.filters
+++ b/MultiSocketRUDP/MultiSocketRUDPServer/MultiSocketRUDP.vcxproj.filters
@@ -191,6 +191,9 @@
     <ClInclude Include="SendPacketInfo.h">
       <Filter>소스 파일\MultiSocketRUDPCore\Core</Filter>
     </ClInclude>
+    <ClInclude Include="RetransmissionScheduler.h">
+      <Filter>소스 파일\MultiSocketRUDPCore\Core</Filter>
+    </ClInclude>
     <ClInclude Include="RUDPIOHandler.h">
       <Filter>소스 파일\MultiSocketRUDPCore\Core\CoreComponent</Filter>
     </ClInclude>

--- a/MultiSocketRUDP/MultiSocketRUDPServer/MultiSocketRUDPCore.cpp
+++ b/MultiSocketRUDP/MultiSocketRUDPServer/MultiSocketRUDPCore.cpp
@@ -13,9 +13,40 @@
 #include "RUDPThreadManager.h"
 #include "RUDPPacketProcessor.h"
 #include "RUDPIOHandler.h"
+#include <chrono>
+
+#ifndef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
+#define CREATE_WAITABLE_TIMER_HIGH_RESOLUTION 0x00000002
+#endif
 
 namespace
 {
+	[[nodiscard]]
+	bool ArmRetransmissionTimer(const HANDLE timerHandle, const std::chrono::steady_clock::time_point deadline)
+	{
+		const auto now = std::chrono::steady_clock::now();
+
+		LARGE_INTEGER dueTime;
+		if (deadline <= now)
+		{
+			dueTime.QuadPart = -1;
+		}
+		else
+		{
+			using HundredNanoseconds = std::chrono::duration<long long, std::ratio<1, 10'000'000>>;
+			const long long remaining = std::chrono::duration_cast<HundredNanoseconds>(deadline - now).count();
+			dueTime.QuadPart = -(remaining > 0 ? remaining : 1);
+		}
+
+		if (SetWaitableTimer(timerHandle, &dueTime, 0, nullptr, nullptr, FALSE) == FALSE)
+		{
+			LOG_ERROR(std::format("SetWaitableTimer failed. error is {}", GetLastError()));
+			return false;
+		}
+
+		return true;
+	}
+
 	FORCEINLINE void SleepRemainingFrameTime(OUT TickSet& tickSet, const unsigned int intervalMs)
 	{
 		const UINT64 now = GetTickCount64();
@@ -132,10 +163,17 @@ void MultiSocketRUDPCore::StopServer()
 	{
 		SetEvent(recvLogicThreadEventStopHandle);
 	}
+
 	if (sessionReleaseStopEventHandle != NULL)
 	{
 		SetEvent(sessionReleaseStopEventHandle);
 	}
+
+	if (retransmissionStopEventHandle != NULL)
+	{
+		SetEvent(retransmissionStopEventHandle);
+	}
+
 	StopAllThreads();
 
 	for (auto const recvLogicThreadEventHandle : recvLogicThreadEventHandles)
@@ -147,21 +185,52 @@ void MultiSocketRUDPCore::StopServer()
 
 		CloseHandle(recvLogicThreadEventHandle);
 	}
+	recvLogicThreadEventHandles.clear();
 
 	if (recvLogicThreadEventStopHandle != NULL)
 	{
 		CloseHandle(recvLogicThreadEventStopHandle);
+		recvLogicThreadEventStopHandle = NULL;
 	}
 
 	if (sessionReleaseEventHandle != NULL)
 	{
 		CloseHandle(sessionReleaseEventHandle);
+		sessionReleaseEventHandle = NULL;
 	}
 
 	if (sessionReleaseStopEventHandle != NULL)
 	{
 		CloseHandle(sessionReleaseStopEventHandle);
+		sessionReleaseStopEventHandle = NULL;
 	}
+
+	if (retransmissionStopEventHandle != NULL)
+	{
+		CloseHandle(retransmissionStopEventHandle);
+		retransmissionStopEventHandle = NULL;
+	}
+
+	for (const auto& scheduler : retransmissionSchedulers)
+	{
+		if (scheduler == nullptr)
+		{
+			continue;
+		}
+
+		if (scheduler->timerHandle != NULL)
+		{
+			CloseHandle(scheduler->timerHandle);
+			scheduler->timerHandle = NULL;
+		}
+
+		if (scheduler->wakeEventHandle != NULL)
+		{
+			CloseHandle(scheduler->wakeEventHandle);
+			scheduler->wakeEventHandle = NULL;
+		}
+	}
+	retransmissionSchedulers.clear();
 
 	Ticker::GetInstance().Stop();
 
@@ -240,32 +309,28 @@ bool MultiSocketRUDPCore::SendPacket(SendPacketInfo* sendPacketInfo) const
 	return true;
 }
 
-bool MultiSocketRUDPCore::EraseSendPacketInfo(OUT SendPacketInfo* eraseTarget, const ThreadIdType threadId)
+void MultiSocketRUDPCore::MarkSendPacketInfoErased(OUT SendPacketInfo* eraseTarget, const ThreadIdType threadId)
 {
 	if (eraseTarget == nullptr || eraseTarget->isErasedPacketInfo.load(std::memory_order_acquire))
 	{
-		return false;
+		return;
 	}
-	bool didFreeRef = false;
+
+	if (threadId >= retransmissionSchedulers.size() || retransmissionSchedulers[threadId] == nullptr)
 	{
-		std::scoped_lock lock(*sendPacketInfoListLock[threadId]);
+		eraseTarget->isErasedPacketInfo.store(true, std::memory_order_release);
+		return;
+	}
+
+	{
+		std::scoped_lock lock(retransmissionSchedulers[threadId]->lock);
 		if (eraseTarget->isErasedPacketInfo.load(std::memory_order_acquire))
 		{
-			return false;
+			return;
 		}
-		if (eraseTarget->isInSendPacketInfoList)
-		{
-			sendPacketInfoList[threadId].erase(eraseTarget->listItor);
-			eraseTarget->isInSendPacketInfoList = false;
-			didFreeRef = true;
-		}
+
 		eraseTarget->isErasedPacketInfo.store(true, std::memory_order_release);
 	}
-	if (didFreeRef == true)
-	{
-		SendPacketInfo::Free(eraseTarget);
-	}
-	return didFreeRef;
 }
 
 RIO_EXTENSION_FUNCTION_TABLE MultiSocketRUDPCore::GetRIOFunctionTable() const
@@ -358,7 +423,7 @@ bool MultiSocketRUDPCore::InitRIO()
 	do
 	{
 		rioManager = std::make_unique<RIOManager>(sessionDelegate);
-		ioHandler = std::make_unique<RUDPIOHandler>(*rioManager, sessionDelegate, contextPool, sendPacketInfoList, sendPacketInfoListLock, maxHoldingPacketQueueSize, retransmissionMs,
+		ioHandler = std::make_unique<RUDPIOHandler>(*rioManager, sessionDelegate, contextPool, retransmissionSchedulers, maxHoldingPacketQueueSize, retransmissionMs,
 			simulatedPacketLossPercent, simulatedPacketLossSeed);
 		if (rioManager == nullptr || ioHandler == nullptr)
 		{
@@ -388,12 +453,21 @@ bool MultiSocketRUDPCore::RunAllThreads()
 		return false;
 	}
 
-	sendPacketInfoList.reserve(numOfWorkerThread);
-	sendPacketInfoListLock.reserve(numOfWorkerThread);
+	retransmissionSchedulers.reserve(numOfWorkerThread);
 
 	recvLogicThreadEventStopHandle = CreateEvent(nullptr, TRUE, FALSE, nullptr);
 	sessionReleaseStopEventHandle = CreateEvent(nullptr, TRUE, FALSE, nullptr);
 	sessionReleaseEventHandle = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+	retransmissionStopEventHandle = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+	if (recvLogicThreadEventStopHandle == NULL
+		|| sessionReleaseStopEventHandle == NULL
+		|| sessionReleaseEventHandle == NULL
+		|| retransmissionStopEventHandle == NULL)
+	{
+		LOG_ERROR(std::format("Thread event handle creation failed. error is {}", GetLastError()));
+		return false;
+	}
+
 	recvIOCompletedContexts.reserve(numOfWorkerThread);
 
 	Ticker::GetInstance().Start(timerTickMs);
@@ -402,8 +476,31 @@ bool MultiSocketRUDPCore::RunAllThreads()
 		recvIOCompletedContexts.emplace_back();
 
 		recvLogicThreadEventHandles.emplace_back(CreateSemaphore(nullptr, 0, LONG_MAX, nullptr));
-		sendPacketInfoList.emplace_back();
-		sendPacketInfoListLock.push_back(std::make_unique<std::mutex>());
+
+		auto scheduler = std::make_unique<RetransmissionScheduler>();
+		scheduler->timerHandle = CreateWaitableTimerExW(nullptr, nullptr, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
+		if (scheduler->timerHandle == nullptr)
+		{
+			scheduler->timerHandle = CreateWaitableTimerExW(nullptr, nullptr, 0, TIMER_ALL_ACCESS);
+		}
+		scheduler->wakeEventHandle = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+		if (scheduler->timerHandle == nullptr || scheduler->wakeEventHandle == nullptr)
+		{
+			LOG_ERROR("Retransmission scheduler handle creation failed");
+			if (scheduler->timerHandle != NULL)
+			{
+				CloseHandle(scheduler->timerHandle);
+				scheduler->timerHandle = NULL;
+			}
+			if (scheduler->wakeEventHandle != NULL)
+			{
+				CloseHandle(scheduler->wakeEventHandle);
+				scheduler->wakeEventHandle = NULL;
+			}
+			return false;
+		}
+
+		retransmissionSchedulers.push_back(std::move(scheduler));
 	}
 
 	threadManager->StartThreads(THREAD_GROUP::SESSION_RELEASE_THREAD, [this](const std::stop_token& stopToken, unsigned char _) { this->RunSessionReleaseThread(stopToken); }, 1);
@@ -587,84 +684,148 @@ void MultiSocketRUDPCore::RunRecvLogicWorkerThread(const std::stop_token& stopTo
 
 void MultiSocketRUDPCore::RunRetransmissionThread(const std::stop_token& stopToken, const ThreadIdType threadId)
 {
-	TickSet tickSet;
-	tickSet.nowTick = GetTickCount64();
+	auto& scheduler = *retransmissionSchedulers[threadId];
+	const HANDLE waitHandles[3] = { scheduler.timerHandle, scheduler.wakeEventHandle, retransmissionStopEventHandle };
+	const HANDLE emptyWaitHandles[2] = { scheduler.wakeEventHandle, retransmissionStopEventHandle };
 
-	auto& thisThreadSendPacketInfoList = sendPacketInfoList[threadId];
-	auto& thisThreadSendPacketInfoListLock = *sendPacketInfoListLock[threadId];
-
-	std::list<SendPacketInfo*> copyList;
+	std::vector<SendPacketInfo*> dueList;
 	while (not stopToken.stop_requested())
 	{
+		dueList.clear();
+		bool hasNext = false;
+		std::chrono::steady_clock::time_point nextDeadline{};
 		{
-			std::scoped_lock lock(thisThreadSendPacketInfoListLock);
-			copyList.clear();
-			for (auto* info : thisThreadSendPacketInfoList)
+			std::scoped_lock lock(scheduler.lock);
+			const auto now = std::chrono::steady_clock::now();
+			while (not scheduler.heap.empty())
 			{
-				if (info->retransmissionTimeStamp > tickSet.nowTick || info->isErasedPacketInfo == true)
+				const RetransmissionHeapEntry& top = scheduler.heap.top();
+				if (top.info->isErasedPacketInfo.load(std::memory_order_acquire) || top.version != top.info->scheduleVersion)
 				{
+					SendPacketInfo* staleInfo = top.info;
+					scheduler.heap.pop();
+					SendPacketInfo::Free(staleInfo);
 					continue;
 				}
 
-				info->AddRefCount();
-				copyList.push_back(info);
+				if (top.deadline > now)
+				{
+					hasNext = true;
+					nextDeadline = top.deadline;
+					break;
+				}
+
+				dueList.push_back(top.info);
+				scheduler.heap.pop();
 			}
 		}
-		
-		for (const auto& sendPacketInfo : copyList)
+
+		for (auto* sendPacketInfo : dueList)
 		{
-			bool shouldDisconnect = false;
-			bool shouldSkip = false;
-			{
-				std::scoped_lock lock(thisThreadSendPacketInfoListLock);
-				if (sendPacketInfo->isErasedPacketInfo)
-				{
-					shouldSkip = true;
-				}
-				else if (++sendPacketInfo->retransmissionCount >= maxPacketRetransmissionCount)
-				{
-					shouldDisconnect = true;
-				}
-				else
-				{
-					sendPacketInfo->retransmissionTimeStamp = GetTickCount64() + retransmissionMs;
-				}
-			}
-
-			if (shouldSkip == true)
-			{
-				SendPacketInfo::Free(sendPacketInfo);
-				continue;
-			}
-
-			if (shouldDisconnect == true)
-			{
-				if (not sendPacketInfo->IsOwnerValid())
-				{
-					SendPacketInfo::Free(sendPacketInfo);
-					continue;
-				}
-
-				sendPacketInfo->owner->DoDisconnect(DISCONNECT_REASON::BY_RETRANSMISSION);
-				SendPacketInfo::Free(sendPacketInfo);
-				continue;
-			}
-
-			if (sendPacketInfo->IsOwnerValid())
-			{
-				sendPacketInfo->owner->OnRetransmissionTimeout();
-			}
-
-			if (not SendPacket(sendPacketInfo) && sendPacketInfo->IsOwnerValid())
-			{
-				sendPacketInfo->owner->DoDisconnect(DISCONNECT_REASON::BY_ERROR);
-			}
-
-			SendPacketInfo::Free(sendPacketInfo);
+			ProcessRetransmission(sendPacketInfo, threadId);
 		}
 
-		SleepRemainingFrameTime(tickSet, retransmissionThreadSleepMs);
+		if (not dueList.empty())
+		{
+			continue;
+		}
+
+		if (hasNext)
+		{
+			if (not ArmRetransmissionTimer(scheduler.timerHandle, nextDeadline))
+			{
+				Sleep(1);
+				continue;
+			}
+
+			const DWORD waitResult = WaitForMultipleObjects(3, waitHandles, FALSE, INFINITE);
+			if (waitResult == WAIT_OBJECT_0 + 2)
+			{
+				break;
+			}
+			if (waitResult == WAIT_FAILED)
+			{
+				LOG_ERROR(std::format("Retransmission wait failed. error is {}", GetLastError()));
+				break;
+			}
+			if (waitResult != WAIT_OBJECT_0 && waitResult != WAIT_OBJECT_0 + 1)
+			{
+				LOG_ERROR(std::format("Retransmission wait returned unexpected result {}", waitResult));
+				break;
+			}
+		}
+		else
+		{
+			const DWORD waitResult = WaitForMultipleObjects(2, emptyWaitHandles, FALSE, INFINITE);
+			if (waitResult == WAIT_OBJECT_0 + 1)
+			{
+				break;
+			}
+			if (waitResult == WAIT_FAILED)
+			{
+				LOG_ERROR(std::format("Empty retransmission wait failed. error is {}", GetLastError()));
+				break;
+			}
+			if (waitResult != WAIT_OBJECT_0)
+			{
+				LOG_ERROR(std::format("Empty retransmission wait returned unexpected result {}", waitResult));
+				break;
+			}
+		}
 	}
+
+	{
+		std::scoped_lock lock(scheduler.lock);
+		while (not scheduler.heap.empty())
+		{
+			SendPacketInfo* info = scheduler.heap.top().info;
+			scheduler.heap.pop();
+			SendPacketInfo::Free(info);
+		}
+	}
+}
+
+void MultiSocketRUDPCore::ProcessRetransmission(SendPacketInfo* sendPacketInfo, const ThreadIdType threadId)
+{
+	auto& scheduler = *retransmissionSchedulers[threadId];
+
+	bool shouldDisconnect = false;
+	{
+		std::scoped_lock lock(scheduler.lock);
+		if (sendPacketInfo->isErasedPacketInfo.load(std::memory_order_acquire))
+		{
+			SendPacketInfo::Free(sendPacketInfo);
+			return;
+		}
+
+		if (++sendPacketInfo->retransmissionCount >= maxPacketRetransmissionCount)
+		{
+			shouldDisconnect = true;
+		}
+	}
+
+	if (shouldDisconnect)
+	{
+		if (sendPacketInfo->IsOwnerValid())
+		{
+			sendPacketInfo->owner->DoDisconnect(DISCONNECT_REASON::BY_RETRANSMISSION);
+		}
+
+		SendPacketInfo::Free(sendPacketInfo);
+		return;
+	}
+
+	if (sendPacketInfo->IsOwnerValid())
+	{
+		sendPacketInfo->owner->OnRetransmissionTimeout();
+	}
+
+	if (not SendPacket(sendPacketInfo) && sendPacketInfo->IsOwnerValid())
+	{
+		sendPacketInfo->owner->DoDisconnect(DISCONNECT_REASON::BY_ERROR);
+	}
+
+	SendPacketInfo::Free(sendPacketInfo);
 }
 
 void MultiSocketRUDPCore::RunSessionReleaseThread(const std::stop_token& stopToken)

--- a/MultiSocketRUDP/MultiSocketRUDPServer/MultiSocketRUDPCore.h
+++ b/MultiSocketRUDP/MultiSocketRUDPServer/MultiSocketRUDPCore.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "IMultiSocketRUDPCore.h"
+#include "RetransmissionScheduler.h"
 #include <list>
+#include <memory>
 #include <thread>
 #include <MSWSock.h>
 #include "../Common/TLS/TLSHelper.h"
@@ -56,8 +58,7 @@ public:
 
 public:
 	bool SendPacket(SendPacketInfo* sendPacketInfo) const override;
-	[[nodiscard]]
-	bool EraseSendPacketInfo(OUT SendPacketInfo* eraseTarget, ThreadIdType threadId) override;
+	void MarkSendPacketInfoErased(OUT SendPacketInfo* eraseTarget, ThreadIdType threadId) override;
 	RIO_EXTENSION_FUNCTION_TABLE GetRIOFunctionTable() const override;
 
 	// ----------------------------------------
@@ -113,8 +114,7 @@ private:
 	inline RUDPSession* GetReleasingSession(SessionIdType sessionId) const;
 
 private:
-	std::vector<std::list<SendPacketInfo*>> sendPacketInfoList;
-	std::vector<std::unique_ptr<std::mutex>> sendPacketInfoListLock;
+	std::vector<std::unique_ptr<RetransmissionScheduler>> retransmissionSchedulers;
 
 private:
 	[[nodiscard]]
@@ -129,6 +129,7 @@ private:
 	void RunIOWorkerThread(const std::stop_token& stopToken, ThreadIdType threadId);
 	void RunRecvLogicWorkerThread(const std::stop_token& stopToken, ThreadIdType threadId);
 	void RunRetransmissionThread(const std::stop_token& stopToken, ThreadIdType threadId);
+	void ProcessRetransmission(SendPacketInfo* sendPacketInfo, ThreadIdType threadId);
 	void RunSessionReleaseThread(const std::stop_token& stopToken);
 	void RunHeartbeatThread(const std::stop_token& stopToken) const;
 
@@ -151,6 +152,7 @@ private:
 	std::vector<HANDLE> recvLogicThreadEventHandles;
 	HANDLE sessionReleaseStopEventHandle{};
 	HANDLE sessionReleaseEventHandle{};
+	HANDLE retransmissionStopEventHandle{};
 
 	// objects
 	std::vector<CListBaseQueue<RecvIOCompletedContext*>> recvIOCompletedContexts;

--- a/MultiSocketRUDP/MultiSocketRUDPServer/RUDPIOHandler.cpp
+++ b/MultiSocketRUDP/MultiSocketRUDPServer/RUDPIOHandler.cpp
@@ -13,8 +13,7 @@
 RUDPIOHandler::RUDPIOHandler(IRIOManager& inRioManager
 	, ISessionDelegate& inSessionDelegate
 	, CTLSMemoryPool<IOContext>& contextPool
-	, std::vector<std::list<SendPacketInfo*>>& sendPacketInfoList
-	, std::vector<std::unique_ptr<std::mutex>>& sendPacketInfoListLock
+	, std::vector<std::unique_ptr<RetransmissionScheduler>>& retransmissionSchedulers
 	, const BYTE inMaxHoldingPacketQueueSize
 	, const unsigned int inRetransmissionMs
 	, const unsigned int inSimulatedPacketLossPercent
@@ -22,8 +21,7 @@ RUDPIOHandler::RUDPIOHandler(IRIOManager& inRioManager
 	: rioManager(inRioManager)
 	, sessionDelegate(inSessionDelegate)
 	, contextPool(contextPool)
-	, sendPacketInfoList(sendPacketInfoList)
-	, sendPacketInfoListLock(sendPacketInfoListLock)
+	, retransmissionSchedulers(retransmissionSchedulers)
 	, retransmissionMs(inRetransmissionMs)
 {
 	if (inSimulatedPacketLossPercent > 0)
@@ -431,21 +429,21 @@ bool RUDPIOHandler::RefreshRetransmissionSendPacketInfo(SendPacketInfo* sendPack
 		return true;
 	}
 
+	auto& scheduler = *retransmissionSchedulers[threadId];
 	{
-		std::scoped_lock lock(*sendPacketInfoListLock[threadId]);
-		if (sendPacketInfo->isErasedPacketInfo == true)
+		std::scoped_lock lock(scheduler.lock);
+		if (sendPacketInfo->isErasedPacketInfo.load(std::memory_order_acquire))
 		{
-			sendPacketInfo = nullptr;
 			return false;
 		}
 
-		sendPacketInfo->retransmissionTimeStamp = GetTickCount64() + retransmissionMs;
-		if (sendPacketInfo->isInSendPacketInfoList)
-		{
-			sendPacketInfoList[threadId].erase(sendPacketInfo->listItor);
-		}
-		sendPacketInfo->listItor = sendPacketInfoList[threadId].emplace(sendPacketInfoList[threadId].end(), sendPacketInfo);
-		sendPacketInfo->isInSendPacketInfoList = true;
+		const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(retransmissionMs);
+		PushRetransmissionSchedule(scheduler, *sendPacketInfo, deadline);
+	}
+
+	if (not SignalRetransmissionWakeEvent(scheduler))
+	{
+		LOG_ERROR(std::format("Retransmission wake event signal failed. error is {}", GetLastError()));
 	}
 
 	return true;

--- a/MultiSocketRUDP/MultiSocketRUDPServer/RUDPIOHandler.h
+++ b/MultiSocketRUDP/MultiSocketRUDPServer/RUDPIOHandler.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "IIOHandler.h"
+#include "RetransmissionScheduler.h"
 #include <vector>
-#include <list>
 #include <mutex>
 #include <memory>
 #include <set>
@@ -69,8 +69,7 @@ public:
 	RUDPIOHandler(IRIOManager& inRioManager
 		, ISessionDelegate& inSessionDelegate
 		, CTLSMemoryPool<IOContext>& contextPool
-		, std::vector<std::list<SendPacketInfo*>>& sendPacketInfoList
-		, std::vector<std::unique_ptr<std::mutex>>& sendPacketInfoListLock
+		, std::vector<std::unique_ptr<RetransmissionScheduler>>& retransmissionSchedulers
 		, BYTE inMaxHoldingPacketQueueSize
 		, unsigned int inRetransmissionMs
 		, unsigned int inSimulatedPacketLossPercent = 0
@@ -122,8 +121,7 @@ private:
 	IRIOManager& rioManager;
 	ISessionDelegate& sessionDelegate;
 	CTLSMemoryPool<IOContext>& contextPool;
-	std::vector<std::list<SendPacketInfo*>>& sendPacketInfoList;
-	std::vector<std::unique_ptr<std::mutex>>& sendPacketInfoListLock;
+	std::vector<std::unique_ptr<RetransmissionScheduler>>& retransmissionSchedulers;
 
 	unsigned int retransmissionMs {};
 

--- a/MultiSocketRUDP/MultiSocketRUDPServer/RUDPSession.cpp
+++ b/MultiSocketRUDP/MultiSocketRUDPServer/RUDPSession.cpp
@@ -102,10 +102,8 @@ void RUDPSession::Disconnect()
 	{
 		rioContext.GetSendContext().ForEachAndClearSendPacketInfoMap([this](SendPacketInfo* info)
 		{
-			if (core.EraseSendPacketInfo(info, threadId) == false)
-			{
-				SendPacketInfo::Free(info);
-			}
+			core.MarkSendPacketInfoErased(info, threadId);
+			SendPacketInfo::Free(info);
 		});
 	}
 	OnReleased();
@@ -216,12 +214,9 @@ bool RUDPSession::SendPacketImmediate(
 	{
 		if (not isReplyType)
 		{
-			const bool didFreeRef = core.EraseSendPacketInfo(sendPacketInfo, threadId);
+			core.MarkSendPacketInfoErased(sendPacketInfo, threadId);
 			rioContext.GetSendContext().EraseSendPacketInfo(inSendPacketSequence);
-			if (didFreeRef == false)
-			{
-				SendPacketInfo::Free(sendPacketInfo);
-			}
+			SendPacketInfo::Free(sendPacketInfo);
 		}
 		else
 		{
@@ -522,10 +517,8 @@ void RUDPSession::OnSendReply(NetBuffer& recvPacket)
 	}
 
 	flowManager.OnAckReceived(packetSequence);
-	if (core.EraseSendPacketInfo(sendPacketInfo, threadId) == false)
-	{
-		SendPacketInfo::Free(sendPacketInfo);
-	}
+	core.MarkSendPacketInfoErased(sendPacketInfo, threadId);
+	SendPacketInfo::Free(sendPacketInfo);
 	TryFlushPendingQueue();
 }
 

--- a/MultiSocketRUDP/MultiSocketRUDPServer/RetransmissionScheduler.h
+++ b/MultiSocketRUDP/MultiSocketRUDPServer/RetransmissionScheduler.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <Windows.h>
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <queue>
+#include <vector>
+
+#include "SendPacketInfo.h"
+
+struct RetransmissionHeapEntry
+{
+	std::chrono::steady_clock::time_point deadline{};
+	uint64_t version{};
+	SendPacketInfo* info{};
+};
+
+struct RetransmissionHeapEntryGreater
+{
+	bool operator()(const RetransmissionHeapEntry& lhs, const RetransmissionHeapEntry& rhs) const noexcept
+	{
+		return lhs.deadline > rhs.deadline;
+	}
+};
+
+struct RetransmissionScheduler
+{
+	std::mutex lock;
+	std::priority_queue<RetransmissionHeapEntry, std::vector<RetransmissionHeapEntry>, RetransmissionHeapEntryGreater> heap;
+	HANDLE timerHandle{};
+	HANDLE wakeEventHandle{};
+};
+
+inline void PushRetransmissionSchedule(
+	OUT RetransmissionScheduler& scheduler,
+	OUT SendPacketInfo& sendPacketInfo,
+	const std::chrono::steady_clock::time_point deadline)
+{
+	++sendPacketInfo.scheduleVersion;
+	sendPacketInfo.AddRefCount();
+	scheduler.heap.push(RetransmissionHeapEntry{ deadline, sendPacketInfo.scheduleVersion, &sendPacketInfo });
+}
+
+[[nodiscard]]
+inline bool SignalRetransmissionWakeEvent(const RetransmissionScheduler& scheduler)
+{
+	return scheduler.wakeEventHandle == NULL || SetEvent(scheduler.wakeEventHandle) != FALSE;
+}

--- a/MultiSocketRUDP/MultiSocketRUDPServer/SendPacketInfo.cpp
+++ b/MultiSocketRUDP/MultiSocketRUDPServer/SendPacketInfo.cpp
@@ -12,8 +12,7 @@ SendPacketInfo::~SendPacketInfo()
 	ownerGeneration = {};
 	retransmissionCount = {};
 	sendPacketSequence = {};
-	retransmissionTimeStamp = {};
-	listItor = {};
+	scheduleVersion = {};
 	isErasedPacketInfo = {};
 	buffer = {};
 	isReplyType = {};
@@ -32,9 +31,8 @@ void SendPacketInfo::Initialize(RUDPSession* inOwner
 	isReplyType = inIsReplyType;
 
 	retransmissionCount = {};
-	retransmissionTimeStamp = {};
+	scheduleVersion = {};
 	isErasedPacketInfo = {};
-	isInSendPacketInfoList = {};
 
 	refCount.store(1, std::memory_order_release);
 }
@@ -46,7 +44,11 @@ bool SendPacketInfo::IsOwnerValid() const
 
 void SendPacketInfo::AddRefCount()
 {
-	refCount.fetch_add(1, std::memory_order_relaxed);
+	const int32_t prev = refCount.fetch_add(1, std::memory_order_relaxed);
+	if (prev <= 0)
+	{
+		LOG_ERROR(std::format("SendPacketInfo refCount is invalid before AddRefCount. prev is {}", prev));
+	}
 }
 
 void SendPacketInfo::Free(SendPacketInfo* deleteTarget)
@@ -56,7 +58,7 @@ void SendPacketInfo::Free(SendPacketInfo* deleteTarget)
 		return;
 	}
 
-	const int prev = deleteTarget->refCount.fetch_sub(1, std::memory_order_acq_rel);
+	const int32_t prev = deleteTarget->refCount.fetch_sub(1, std::memory_order_acq_rel);
 	if (prev <= 0)
 	{
 		LOG_ERROR(std::format("SendPacketInfo refCount is invalid prev is {}", prev));

--- a/MultiSocketRUDP/MultiSocketRUDPServer/SendPacketInfo.h
+++ b/MultiSocketRUDP/MultiSocketRUDPServer/SendPacketInfo.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <list>
 #include <atomic>
+#include <cstdint>
 #include <NetServerSerializeBuffer.h>
 
 #include "../Common/etc/CoreType.h"
@@ -17,12 +17,10 @@ struct SendPacketInfo
 	uint32_t ownerGeneration{};
 	PacketRetransmissionCount retransmissionCount{};
 	PacketSequence sendPacketSequence{};
-	unsigned long long retransmissionTimeStamp{};
+	uint64_t scheduleVersion{};
 	std::atomic_bool isErasedPacketInfo{};
-	bool isInSendPacketInfoList{};
 	bool isReplyType{};
-	std::list<SendPacketInfo*>::iterator listItor;
-	std::atomic_int8_t refCount{};
+	std::atomic_int32_t refCount{};
 
 	SendPacketInfo() = default;
 	~SendPacketInfo();


### PR DESCRIPTION
  * RetransmissionScheduler를 추가해 재전송 대상을 priority queue로 관리
  * scheduleVersion과 tombstone 상태로 stale heap entry를 판별
  * 기존 sendPacketInfoList 기반 재전송 목록 제거

* SendPacketInfo 소유권과 삭제 흐름 정리
  * EraseSendPacketInfo를 MarkSendPacketInfoErased로 변경해 tombstone 처리만 담당
  * ACK, disconnect, send 실패 경로의 Free 책임을 호출부에서 명확히 처리
  * refCount를 int32_t로 확장하고 비정상 ref 조작 로그 추가

* 재전송 스레드 wake/timer 처리 보강
  * waitable timer 기반으로 다음 재전송 deadline까지 대기
  * timer/wait/wake event 실패 로그 처리 추가
  * StopServer와 생성 실패 경로에서 scheduler handle 정리 보강

* 재전송 스케줄러 테스트 추가
  * heap push 시 ref 증가와 wake event signal 검증
  * scheduleVersion 기반 stale entry 판별 검증
  * erased packet heap entry의 ref 반환 검증