### PR TITLE
* 클라이언트 Disconnect 종료 경로 안정화

### DIFF
--- a/MultiSocketRUDP/IntegrationTest/IntegrationTest.cpp
+++ b/MultiSocketRUDP/IntegrationTest/IntegrationTest.cpp
@@ -662,7 +662,7 @@ namespace
 		ClientHarnessProcess process;
 		ASSERT_TRUE(process.Start(BuildClientArgs({ L"--scenario", L"disconnect" })));
 
-		EXPECT_TRUE(WaitUntil(10s, [this]()
+		EXPECT_TRUE(WaitUntil(25s, [this]()
 		{
 			return server->GetAllDisconnectedCount() == 1 &&
 				GetSessionStats().disconnectedCount.load(std::memory_order_relaxed) == 1 &&

--- a/MultiSocketRUDP/MultiSocketRUDPClient/RUDPClientCore.cpp
+++ b/MultiSocketRUDP/MultiSocketRUDPClient/RUDPClientCore.cpp
@@ -705,8 +705,8 @@ void RUDPClientCore::Disconnect()
 	}
 
 	constexpr auto packetType = PACKET_TYPE::DISCONNECT_TYPE;
-	constexpr PacketSequence packetSequence = 0;
-	*buffer << packetType;
+	const PacketSequence packetSequence = ++lastSendPacketSequence;
+	*buffer << packetType << packetSequence;
 
 	PacketCryptoHelper::EncodePacket(
 		*buffer,

--- a/MultiSocketRUDP/MultiSocketRUDPClient/RUDPClientCore.cpp
+++ b/MultiSocketRUDP/MultiSocketRUDPClient/RUDPClientCore.cpp
@@ -682,6 +682,9 @@ void RUDPClientCore::SendPacket(OUT IPacket& packet)
 
 void RUDPClientCore::Disconnect()
 {
+	serverAliveChecker.StopServerAliveCheck();
+	isConnected = false;
+
 	NetBuffer* buffer = NetBuffer::Alloc();
 	if (buffer == nullptr)
 	{
@@ -703,13 +706,18 @@ void RUDPClientCore::Disconnect()
 		true
 	);
 
+	if (sendEventHandles[0] == nullptr)
+	{
+		NetBuffer::Free(buffer);
+		return;
+	}
+
 	{
 		std::scoped_lock lock(sendBufferQueueLock);
 		sendBufferQueue.Enqueue(buffer);
 	}
 
 	ReleaseSemaphore(sendEventHandles[0], 1, nullptr);
-	isConnected = false;
 }
 
 #if _DEBUG

--- a/MultiSocketRUDP/MultiSocketRUDPClient/RUDPClientCore.cpp
+++ b/MultiSocketRUDP/MultiSocketRUDPClient/RUDPClientCore.cpp
@@ -90,40 +90,46 @@ bool RUDPClientCore::Start(const std::wstring& clientCoreOptionFile, const std::
 
 void RUDPClientCore::Stop()
 {
-	if (isStopped.exchange(true, std::memory_order_acq_rel))
 	{
-		return;
-	}
+		std::scoped_lock lock(lifecycleLock);
+		if (isStopped.exchange(true, std::memory_order_acq_rel))
+		{
+			return;
+		}
 
-	if (sessionBrokerSocket != INVALID_SOCKET)
-	{
-		closesocket(sessionBrokerSocket);
-		sessionBrokerSocket = INVALID_SOCKET;
-	}
+		if (sessionBrokerSocket != INVALID_SOCKET)
+		{
+			closesocket(sessionBrokerSocket);
+			sessionBrokerSocket = INVALID_SOCKET;
+		}
 
-	threadStopFlag = true;
-	if (sendEventHandles[1] != nullptr)
-	{
-		SetEvent(sendEventHandles[1]);
-	}
+		threadStopFlag = true;
+		if (sendEventHandles[1] != nullptr)
+		{
+			SetEvent(sendEventHandles[1]);
+		}
 
-	if (rudpSocket != INVALID_SOCKET)
-	{
-		closesocket(rudpSocket);
-		rudpSocket = INVALID_SOCKET;
+		if (rudpSocket != INVALID_SOCKET)
+		{
+			closesocket(rudpSocket);
+			rudpSocket = INVALID_SOCKET;
+		}
 	}
 
 	JoinThreads();
 
-	if (sendEventHandles[0] != nullptr)
 	{
-		CloseHandle(sendEventHandles[0]);
-		sendEventHandles[0] = nullptr;
-	}
-	if (sendEventHandles[1] != nullptr)
-	{
-		CloseHandle(sendEventHandles[1]);
-		sendEventHandles[1] = nullptr;
+		std::scoped_lock lock(lifecycleLock);
+		if (sendEventHandles[0] != nullptr)
+		{
+			CloseHandle(sendEventHandles[0]);
+			sendEventHandles[0] = nullptr;
+		}
+		if (sendEventHandles[1] != nullptr)
+		{
+			CloseHandle(sendEventHandles[1]);
+			sendEventHandles[1] = nullptr;
+		}
 	}
 
 	{
@@ -683,6 +689,12 @@ void RUDPClientCore::SendPacket(OUT IPacket& packet)
 void RUDPClientCore::Disconnect()
 {
 	serverAliveChecker.StopServerAliveCheck();
+	std::scoped_lock lock(lifecycleLock);
+	if (isStopped.load(std::memory_order_acquire))
+	{
+		return;
+	}
+
 	isConnected = false;
 
 	NetBuffer* buffer = NetBuffer::Alloc();

--- a/MultiSocketRUDP/MultiSocketRUDPClient/RUDPClientCore.h
+++ b/MultiSocketRUDP/MultiSocketRUDPClient/RUDPClientCore.h
@@ -93,6 +93,7 @@ private:
 	std::atomic_bool threadStopFlag{};
 	std::atomic_bool isConnected{};
 	std::atomic_bool hasClientProcessReference{};
+	std::mutex lifecycleLock;
 
 #pragma region SessionGetter
 #if USE_IOCP_SESSION_GETTER

--- a/MultiSocketRUDP/MultiSocketRUDPClient/ServerAliveChecker.cpp
+++ b/MultiSocketRUDP/MultiSocketRUDPClient/ServerAliveChecker.cpp
@@ -55,6 +55,11 @@ void ServerAliveChecker::RunServerAliveCheckerThread()
 	while (not isStopped)
 	{
 		Sleep(checkIntervalMs);
+		if (isStopped.load(std::memory_order_acquire))
+		{
+			break;
+		}
+
 		if (not IsServerAlive(getNextRecvSequenceFunction()))
 		{
 			const auto log = Logger::MakeLogObject<ClientLog>();


### PR DESCRIPTION
  * 서버 alive-check 스레드를 먼저 중지해 Disconnect와 Stop 사이의 동시 접근 가능성 축소
  * send 이벤트 핸들이 없는 경우 버퍼를 해제하고 반환하도록 방어 처리
  * CI disconnect 통합 테스트에서 발생한 access violation 가능 경로 완화